### PR TITLE
Pin requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 numpy
-sqlalchemy
-flask
-flask_babel
-flask_sqlalchemy
+SQLAlchemy<2.0.0
+Flask
+Flask-Babel
+Flask-SQLAlchemy<3.0.0
 dnspython
 gunicorn
 python2-secrets ; python_version < '3.6'  # secrets module is backported in this module

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ Flask-Babel
 Flask-SQLAlchemy<3.0.0
 dnspython
 gunicorn
+python-dateutil
 python2-secrets ; python_version < '3.6'  # secrets module is backported in this module
+requests


### PR DESCRIPTION
`flask-sqlalchemy` and `SQLAlchemy` got new major versions.
For now these are incompatible with the code.